### PR TITLE
Adding the property border to the fields

### DIFF
--- a/backend/database/migrations/1625618714239-Adding_Border_To_Field.ts
+++ b/backend/database/migrations/1625618714239-Adding_Border_To_Field.ts
@@ -1,0 +1,28 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddingBorderToField1625618714239 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        let documents = await queryRunner.query(`SELECT id,fields FROM documents`)
+        documents = documents.map(doc=>{
+            doc.fields = doc.fields.map(f=>({...f, border:0}))
+            return doc
+        })
+
+        await Promise.all(documents.map(doc=> queryRunner.query(`UPDATE documents SET fields=$1 WHERE id=$2`,[JSON.stringify(doc.fields),doc.id])))
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        let documents = await queryRunner.query(`SELECT id,fields FROM documents`)
+        documents = documents.map(doc=>{
+            doc.fields = doc.fields.map(f=>{
+                delete f.border
+                return f
+            })
+            return doc
+        })
+
+        await Promise.all(documents.map(doc=> queryRunner.query(`UPDATE documents SET fields=$1 WHERE id=$2`,[JSON.stringify(doc.fields),doc.id])))
+    }
+
+}

--- a/backend/src/document/dto/field.dto.ts
+++ b/backend/src/document/dto/field.dto.ts
@@ -135,5 +135,9 @@ export class Field {
 
     @IsOptional() @IsNumber() @ApiPropertyOptional()
     @Expose()
-    size: string = 'col-12'
+    size: string
+
+    @IsOptional() @IsNumber() @ApiPropertyOptional()
+    @Expose()
+    border: number
 }

--- a/frontend/src/dynamic-documents/src/core/DDField.ts
+++ b/frontend/src/dynamic-documents/src/core/DDField.ts
@@ -96,6 +96,8 @@ export class DDField {
   // Identifier used in the fillmaps
   map_id?: string
 
+  border: number = 0;
+
   static createFromType (type: DDFieldType): DDField {
     let field = new DDField()
     field.name = type.name


### PR DESCRIPTION
1. Added "border" to the DDField frontend class, it has a default value of 0
2. Added "border" as a numeric property accepted by the backend
3. Added a migration for adding "border" to any existing field